### PR TITLE
Fix natural language parser to return structured object

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,17 @@
+import datetime
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from utils.parser import parse_natural, ParsedTask
+
+
+def test_parse_natural_returns_parsed_task():
+    text = "Напомни в 10:00 почитать книгу"
+    parsed = parse_natural(text, 'ru')
+    assert isinstance(parsed, ParsedTask)
+    assert parsed.text == "почитать книгу"
+    assert isinstance(parsed.date_time, datetime.datetime)
+    assert parsed.date_time.hour == 10
+    assert parsed.repeat is None

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -1,8 +1,43 @@
-from dateutil import parser
-import re
+"""Utility helpers for converting user text into structured reminders."""
 
-def parse_natural(text: str, lang: str) -> dict:
-    # Наивный парсер: реальное NLP можно подключить отдельно
-    dt = parser.parse(text, dayfirst=True)
-    cleaned = re.sub(r"(Напомни|Remind|завтра|в|\d{1,2}[\.:]\d{2})", "", text).strip()
-    return {'text': cleaned, 'date_time': dt}
+from dataclasses import dataclass
+from datetime import datetime
+import re
+from dateutil import parser
+
+
+@dataclass
+class ParsedTask:
+    """Simple container for data extracted from a natural language request."""
+
+    text: str
+    date_time: datetime
+    repeat: str | None = None
+
+
+def parse_natural(text: str, lang: str) -> ParsedTask:
+    """Parse a natural language reminder description.
+
+    The original implementation returned a plain ``dict``. Downstream callers
+    expected attributes like ``parsed.text`` and ``parsed.date_time`` which
+    caused an ``AttributeError`` at runtime.  Returning a dataclass makes the
+    structure explicit and avoids such errors.
+
+    Args:
+        text: Raw user message containing the reminder request.
+        lang: Language code (currently unused but kept for future NLP).
+
+    Returns:
+        ParsedTask: Structured representation of the reminder.
+    """
+
+    # ``fuzzy=True`` allows the parser to ignore unknown words such as
+    # "Напомни" or "завтра" while still extracting a valid datetime.
+    dt = parser.parse(text, dayfirst=True, fuzzy=True)
+
+    cleaned = re.sub(
+        r"(Напомни|Remind|завтра|в|\d{1,2}[\.:]\d{2})",
+        "",
+        text,
+    ).strip()
+    return ParsedTask(text=cleaned, date_time=dt)


### PR DESCRIPTION
## Summary
- return a dataclass from `parse_natural` instead of a dict and enable fuzzy datetime parsing
- add unit test for parsing reminders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894099cab9c8331ac701a82718e704a