### PR TITLE
Add .env example and document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Environment variable examples for Telegram Secretary Bot
+TOKEN=your-telegram-bot-token
+DB_URL=postgresql://user:password@host:port/database
+# Optional: default language code (e.g., 'ru' or 'en')
+DEFAULT_LANGUAGE=ru

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@
 
 1. Склонировать репозиторий.
 2. Скопировать шаблон `.env.example` в `.env` и заполнить:
+   - `TOKEN` — токен Telegram‑бота
+   - `DB_URL` — строка подключения к базе PostgreSQL
+   - `DEFAULT_LANGUAGE` — код языка по умолчанию (например, `ru` или `en`)
+
    ```bash
    cp .env.example .env
    ```


### PR DESCRIPTION
## Summary
- add sample `.env.example` with required settings
- detail environment variables in setup instructions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940bf716588331a8f346e0b17385f7