### PR TITLE
Add parser tests and improve natural language parsing

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,36 @@
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from utils.parser import parse_natural
+
+
+def _expected_datetime(days_ahead: int, hour: int, minute: int) -> datetime:
+    """Helper to build expected datetime objects for tests."""
+    base = datetime.now() + timedelta(days=days_ahead)
+    return base.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def test_parse_natural_russian_phrase():
+    """Typical Russian reminder should extract text and tomorrow's time."""
+    res = parse_natural("Напомни завтра в 10:00 купить хлеб", "ru")
+    assert res["text"] == "купить хлеб"
+    assert res["date_time"] == _expected_datetime(1, 10, 0)
+
+
+def test_parse_natural_english_phrase():
+    """English phrase with "tomorrow" should also be supported."""
+    res = parse_natural("Remind tomorrow at 08:30 buy milk", "en")
+    assert res["text"] == "buy milk"
+    assert res["date_time"] == _expected_datetime(1, 8, 30)
+
+
+def test_parse_natural_time_with_dot():
+    """Times written with dots should be normalised to parse correctly."""
+    res = parse_natural("Напомни завтра в 9.30 позвонить маме", "ru")
+    assert res["text"] == "позвонить маме"
+    assert res["date_time"] == _expected_datetime(1, 9, 30)
+

--- a/utils/parser.py
+++ b/utils/parser.py
@@ -1,8 +1,48 @@
+from datetime import datetime, timedelta
 from dateutil import parser
 import re
 
+
 def parse_natural(text: str, lang: str) -> dict:
-    # Наивный парсер: реальное NLP можно подключить отдельно
-    dt = parser.parse(text, dayfirst=True)
-    cleaned = re.sub(r"(Напомни|Remind|завтра|в|\d{1,2}[\.:]\d{2})", "", text).strip()
-    return {'text': cleaned, 'date_time': dt}
+    """Very naive natural language parser.
+
+    Currently supports Russian word "завтра" by converting it to the actual
+    date before passing the string to :func:`dateutil.parser.parse`.
+
+    Parameters
+    ----------
+    text: str
+        User input describing reminder text and date/time.
+    lang: str
+        Currently unused, kept for future localisation.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``text`` and ``date_time``.
+    """
+
+    now = datetime.now()
+
+    # Replace the word "завтра" with tomorrow's date so that dateutil can
+    # understand it. Any casing of the word is handled.
+    text_to_parse = text
+
+    if re.search(r"\bзавтра\b", text, flags=re.IGNORECASE):
+        tomorrow = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+        text_to_parse = re.sub(r"\bзавтра\b", tomorrow, text_to_parse, flags=re.IGNORECASE)
+    if re.search(r"\btomorrow\b", text, flags=re.IGNORECASE):
+        tomorrow = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+        text_to_parse = re.sub(r"\btomorrow\b", tomorrow, text_to_parse, flags=re.IGNORECASE)
+
+    # Convert times written with a dot to a format understood by dateutil.
+    text_to_parse = re.sub(r"(\d{1,2})\.(\d{2})", r"\1:\2", text_to_parse)
+
+    dt = parser.parse(text_to_parse, dayfirst=True, fuzzy=True)
+    cleaned = re.sub(
+        r"(Напомни|Remind|завтра|tomorrow|\bв\b|\bat\b|\d{1,2}[\.:]\d{2})",
+        "",
+        text,
+        flags=re.IGNORECASE,
+    ).strip()
+    return {"text": cleaned, "date_time": dt}


### PR DESCRIPTION
## Summary
- expand naive parser to handle Russian/English "tomorrow" and dot-separated times
- add tests validating typical phrases and edge cases for parser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68940bf81cfc8331972f5359c48e525b